### PR TITLE
Store serde queries in a LinearMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "rjpb"
 version = "0.1.0"
 dependencies = [
  "json 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linear-map 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pikkr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,6 +27,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "json"
 version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linear-map"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -68,6 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac17257442c2ed77dbc9fd555cf83c58b0c7f7d0e8f2ae08c0ac05c72842e1f6"
 "checksum json 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c2b0b20012c690c7f0578893637d3b4b61511e3fe4774389b5e77dd8023bc3e4"
+"checksum linear-map 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum pikkr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b4b189a0ff182e746eff5267b131e1831635f1a91d67bdb323cfa0edfcdc04"
 "checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Keiji Yoshida <kjmrknsn@gmail.com>"]
 
 [dependencies]
 json = "0.11.9"
+linear-map = "1.2.0"
 pikkr = "0.6.0"
 serde = "1.0.11"
 serde_json = "1.0.2"

--- a/src/serde_pikkr.rs
+++ b/src/serde_pikkr.rs
@@ -1,4 +1,6 @@
-use std::collections::BTreeMap as Map;
+extern crate linear_map;
+
+use self::linear_map::LinearMap as Map;
 use std::{fmt, str};
 use serde::de::{DeserializeSeed, Deserializer, Visitor, MapAccess, IgnoredAny, Error};
 use serde_json::{self, Value};


### PR DESCRIPTION
Ordinarily serde code will use #[derive(Deserialize)] for field names known at compile time. That turns into a match statement over field names (https://serde.rs/deserialize-struct.html), so a LinearMap is a better approximation.